### PR TITLE
sourceByGlobs migration follow-ups

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -515,44 +515,50 @@ let
       throw "repoRevToName: invalid kind";
 
   /**
-    Filter sources by a list of double star glob patterns.
+    Filter a source tree by a list of doublestar-style glob patterns,
+    returning a source that only contains paths matching at least one
+    pattern. `*` matches a single path component, and `**` matches any
+    number of components.
 
     # Inputs
 
     `src`
 
-    : 1\. Function argument
+    : The source tree to filter.
 
     `patterns`
 
-    : 2\. Function argument
+    : List of glob patterns to include, e.g. `[ "*.py" "src/**" ]`.
+      A leading `**` (e.g. `**\/*.py` for all `.py` files at any depth)
+      is also supported; the `\` here is just a Nix string escape used
+      to avoid closing this comment.
 
     # Examples
     :::{.example}
     ## `sourceByGlobs` usage example
 
-    - Include all .py files recursively
+    - Include everything under a subdirectory
     ```nix
-    src = sourceByGlobs ./my-subproject ["**\/*.py" ]
+    src = sourceByGlobs ./. [ "src/**" "tests/**" ]
     ```
 
     - Include all .py files in root directory only
     ```nix
-    src = sourceByGlobs ./my-subproject ["*.py" ]
+    src = sourceByGlobs ./. [ "*.py" ]
     ```
 
     :::
   */
   sourceByGlobs =
     let
-      splitPath = path: filter isString (split "\/" path);
+      splitPath = path: filter isString (split "/" path);
       # Make component regex
       mkRe =
         s:
         if s == "**" then
           ".*" # Has special handling below
         else
-          concatStrings (map (tok: if isList tok then "[^\/]*" else escapeRegex tok) (split "\\*+" s));
+          concatStrings (map (tok: if isList tok then "[^/]*" else escapeRegex tok) (split "\\*+" s));
 
       # Make a source filter function from pattern
       mkMatcher =

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -70,4 +70,16 @@ dir="$(nix-instantiate --eval --strict --read-write-mode --json --expr '(with im
 EOF
 ) || die "cleanSourceWith + cleanSource"
 
+
+dir="$(nix-instantiate --eval --strict --read-write-mode --json --expr '(with import <nixpkgs/lib>; "${
+  sources.sourceByGlobs '"$work"' [ "*.md" "**/*.o" ]
+}")' | crudeUnquoteJSON)"
+(cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
+.
+./module.o
+./README.md
+EOF
+) || die "sourceByGlobs 1"
+
+
 echo >&2 tests ok

--- a/pkgs/applications/editors/vim/plugins/utils/updater.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/updater.nix
@@ -43,7 +43,7 @@ buildPythonApplication {
         neovim-unwrapped
         nurl
       ]
-    }" --prefix PYTHONPATH : "${./.}" )
+    }" --prefix PYTHONPATH : "${lib.sources.sourceByGlobs ./. [ "**/*.py" ]}" )
     wrapPythonPrograms
   '';
 

--- a/pkgs/development/compilers/purescript/purescript/test-minimal-module/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/test-minimal-module/default.nix
@@ -1,11 +1,12 @@
 {
+  lib,
   runCommand,
   purescript,
   nodejs,
 }:
 
 runCommand "purescript-test-minimal-module" { } ''
-  ${purescript}/bin/purs compile -o ./output ${./.}/Main.purs
+  ${purescript}/bin/purs compile -o ./output ${lib.sources.sourceByGlobs ./. [ "*.purs" "*.js" ]}/Main.purs
 
   echo 'import {main} from "./output/Main/index.js"; main()' > node.mjs
 

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -72,8 +72,8 @@ stdenv.mkDerivation {
     )
   );
 
-  src = lib.sourceByRegex ./. [
-    ".*\\.java"
+  src = lib.sources.sourceByGlobs ./. [
+    "**/*.java"
   ];
   # On Linux, this can be C.UTF-8, but darwin + zulu requires en_US.UTF-8
   LANG = "en_US.UTF-8";


### PR DESCRIPTION
## Summary

Two small follow-ups on top of #462272, to show real world usage.

## Test plan
- [x] `lib/tests/sources.sh` passes
- [x] `nix-build -A vimPluginsUpdater` succeeds (cache-hit on identical .drv, then verified filtered source contents)
- [x] `purescript.tests.minimal-module` builds and prints "hello world"

🤖 Generated with [Claude Code](https://claude.com/claude-code)